### PR TITLE
RMC sentence length fix.

### DIFF
--- a/nmea-adapter/src/main/java/com/esri/geoevent/adapter/nmea/NMEAGPRMCMessageTranslator.java
+++ b/nmea-adapter/src/main/java/com/esri/geoevent/adapter/nmea/NMEAGPRMCMessageTranslator.java
@@ -52,7 +52,7 @@ public class NMEAGPRMCMessageTranslator extends NMEAMessageTranslator
   @Override
   protected void validate(String[] data) throws ValidationException
   {
-    if (data == null || data.length != 12)
+    if (data == null || data.length < 12 || data.length > 14)
       throw new ValidationException("NMEAGPRMC message data is invalid.");
   }
 }


### PR DESCRIPTION
RMC sentences can contain 12, 13 or 14 fields depending on the manufacturer's implementation. This changes the validation to only throw an error if the data is null, less then 12 fields, or more than 14 fields.
