### PR TITLE
Add specific parser for NMEAGNRMC messages

### DIFF
--- a/nmea-adapter/src/main/java/com/esri/geoevent/adapter/nmea/NMEAGNRMCMessageTranslator.java
+++ b/nmea-adapter/src/main/java/com/esri/geoevent/adapter/nmea/NMEAGNRMCMessageTranslator.java
@@ -1,0 +1,61 @@
+/*
+  Copyright 1995-2019 Esri
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+  For additional information, contact:
+  Environmental Systems Research Institute, Inc.
+  Attn: Contracts Dept
+  380 New York Street
+  Redlands, California, USA 92373
+
+  email: contracts@esri.com
+*/
+
+package com.esri.geoevent.adapter.nmea;
+
+import com.esri.ges.core.geoevent.FieldException;
+import com.esri.ges.core.geoevent.GeoEvent;
+import com.esri.ges.core.validation.ValidationException;
+
+public class NMEAGNRMCMessageTranslator extends NMEAMessageTranslator
+{
+  @Override
+  public void translate(GeoEvent geoEvent, String[] data) throws FieldException
+  {
+    int i = 1;
+    geoEvent.setField(i++, toTime(data[1], data[9]));
+    geoEvent.setField(i++, toPoint(data[3], data[5], "N".equals(data[4]), "E".equals(data[6])));
+    geoEvent.setField(i++, data[2]);
+    geoEvent.setField(i++, convertToDouble(data[7]));
+    geoEvent.setField(i++, convertToDouble(data[8]));
+    geoEvent.setField(i++, convertToDouble(data[10]));
+
+    if (data.length == 12)
+      geoEvent.setField(i++, data[11].split("\\*")[0]);
+    else
+    {
+      geoEvent.setField(i++, data[11]);
+      geoEvent.setField(i++, data[12].split("\\*")[0]);
+    }
+    if (LOGGER.isTraceEnabled() && data != null && data.length > 0)
+      LOGGER.trace("Translated GNRMC {0} to {1}", String.join(" ", data), geoEvent);
+  }
+
+  @Override
+  protected void validate(String[] data) throws ValidationException
+  {
+    if (data == null || data.length < 12)
+      throw new ValidationException(LOGGER.translate("INVALID_NMEAGNRMC_MSG"));
+  }
+}

--- a/nmea-adapter/src/main/java/com/esri/geoevent/adapter/nmea/NmeaInboundAdapter.java
+++ b/nmea-adapter/src/main/java/com/esri/geoevent/adapter/nmea/NmeaInboundAdapter.java
@@ -59,6 +59,7 @@ public class NmeaInboundAdapter extends InboundAdapterBase
     translators.put("NMEAGPRMC", new NMEAGPRMCMessageTranslator());
     translators.put("NMEAGPGSA", new NMEAGPGSAMessageTranslator());
     translators.put("NMEAGPVTG", new NMEAGPVTGMessageTranslator());
+    translators.put("NMEAGNRMC", new NMEAGNRMCMessageTranslator());
     LOGGER.trace("Created NMEA adapter and translators");
   }
 

--- a/nmea-adapter/src/main/resources/adapter-definition.xml
+++ b/nmea-adapter/src/main/resources/adapter-definition.xml
@@ -74,6 +74,31 @@
         <fieldDefinition name="Mode" type="String" />
       </fieldDefinitions>
     </geoEventDefinition>
+    <geoEventDefinition name="NMEAGNRMC">
+      <fieldDefinitions>
+        <fieldDefinition name="DeviceId" type="String">
+          <fieldDefinitionTag>
+            <name>TRACK_ID</name>
+          </fieldDefinitionTag>
+        </fieldDefinition>
+        <fieldDefinition name="TimeStamp" type="Date">
+          <fieldDefinitionTag>
+            <name>TIME_START</name>
+          </fieldDefinitionTag>
+        </fieldDefinition>
+        <fieldDefinition name="Shape" type="Geometry">
+          <fieldDefinitionTag>
+            <name>GEOMETRY</name>
+          </fieldDefinitionTag>
+        </fieldDefinition>
+        <fieldDefinition name="Validity" type="String" />
+        <fieldDefinition name="Speed" type="Double" />
+        <fieldDefinition name="Course" type="Double" />
+        <fieldDefinition name="Variation" type="Double" />
+        <fieldDefinition name="EastWest" type="String" />
+        <fieldDefinition name="Mode" type="String" />
+      </fieldDefinitions>
+    </geoEventDefinition>
     <geoEventDefinition name="NMEAGPGSA">
       <fieldDefinitions>
         <fieldDefinition name="DeviceId" type="String">

--- a/nmea-adapter/src/main/resources/com/esri/geoevent/adapter/nmea-adapter.properties
+++ b/nmea-adapter/src/main/resources/com/esri/geoevent/adapter/nmea-adapter.properties
@@ -17,4 +17,5 @@ INVALID_NMEAGPGG_MSG=NMEAGPGG message data is invalid.
 INVALID_NMEAGPGSA_MSG=NMEAGPGSA message data is invalid.
 INVALID_NMEAGPGLL_MSG=NMEAGPGLL message data is invalid.
 INVALID_NMEAGPRMC_MSG=NMEAGPRMC message data is invalid.
+INVALID_NMEAGNRMC_MSG=NMEAGNRMC message data is invalid.
 INVALID_NMEAGPVTG_MSG=NMEAGPVTG message data is invalid.


### PR DESCRIPTION
This PR contains the necessary parser to ingest the data as described in issue https://github.com/Esri/nmea-for-geoevent/issues/7

It enables the parsing of RMC frames that have navigation satellite system receiver talker identify is set to multiple system.